### PR TITLE
Describe fixes

### DIFF
--- a/lib/breaking_pp/application.ex
+++ b/lib/breaking_pp/application.ex
@@ -19,7 +19,7 @@ defmodule BreakingPP.Application do
 
   defp start_endpoints do
     dispatch = :cowboy_router.compile([
-      {:"_", [
+      {:_, [
           {"/status", BreakingPP.StatusHandler, []},
           {"/sessions/:id", BreakingPP.SessionsHandler, []},
           {"/sessions", BreakingPP.SessionsListHandler, []}]}

--- a/lib/breaking_pp/eventually.ex
+++ b/lib/breaking_pp/eventually.ex
@@ -1,8 +1,11 @@
 defmodule BreakingPP.Eventually do
   require Logger
 
-  def eventually(f, retries \\ 30, sleep \\ 1_000)
-  def eventually(_, 0, _), do: false
+  def eventually(f, retries \\ 120, sleep \\ 1_000)
+  def eventually(f, 0, _) do
+    Logger.error("Retries exceeded while waiting for: #{inspect f}")
+    false
+  end
   def eventually(f, retries, sleep) do
     result = try do
       f.()

--- a/mix.exs
+++ b/mix.exs
@@ -29,9 +29,7 @@ defmodule BreakingPp.MixProject do
     [
       {:cowboy, "~> 2.4"},
       {:poison, "~> 3.1"},
-      {:phoenix_pubsub,
-        git: "https://github.com/distributed-owls/phoenix_pubsub.git",
-        branch: "master"},
+      {:phoenix_pubsub, github: "phoenixframework/phoenix_pubsub"},
       {:recon, "~> 2.3"},
       {:distillery, "~> 1.5", runtime: false},
       {:httpoison, "~> 1.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -11,7 +11,7 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "mock": {:hex, :mock, "0.3.2", "e98e998fd76c191c7e1a9557c8617912c53df3d4a6132f561eb762b699ef59fa", [:mix], [{:meck, "~> 0.8.8", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
-  "phoenix_pubsub": {:git, "https://github.com/distributed-owls/phoenix_pubsub.git", "b0a913ca86e658b023014cd18576124e68c3a6cd", [branch: "master"]},
+  "phoenix_pubsub": {:git, "https://github.com/phoenixframework/phoenix_pubsub.git", "50c1da2edd441b7af53dc646c92eaee3725a94a2", []},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "propcheck": {:hex, :propcheck, "1.0.5", "0d6be01f57c9c1046610d6b02f013cc9e87b2ca3901e39c2266554045695c0d1", [:mix], [{:proper, "~> 1.2.0", [hex: :proper, repo: "hexpm", optional: false]}], "hexpm"},
   "proper": {:hex, :proper, "1.2.0", "1466492385959412a02871505434e72e92765958c60dba144b43863554b505a4", [:make, :mix, :rebar3], [], "hexpm"},

--- a/test/large/cluster_join_leave_counterexamples_test.exs
+++ b/test/large/cluster_join_leave_counterexamples_test.exs
@@ -1,0 +1,82 @@
+defmodule BreakingPP.ClusterJoinLeaveCounterExamplesTest do
+  @moduledoc """
+  This is a set of found counterexamples related to starting and stopping nodes in the cluster
+  and issues with synchronizing state in the cluster after these events.
+
+  Counterexamples from this module have been fixed in this squash-merge commit:
+  [e5f3641](https://github.com/phoenixframework/phoenix_pubsub/commit/e5f3641f8b8d076cce5810dd1deb6fc6f868bbf9).
+  """
+  use ExUnit.Case
+  import BreakingPP.Eventually
+  alias BreakingPP.RealWorld.Cluster
+
+  @moduletag timeout: 300_000
+
+  @doc """
+  Empty deltas were sometimes chosen when extracing newest delta from the state.
+  Fixed by [b7170eb](https://github.com/distributed-owls/phoenix_pubsub/commit/b7170eb89fe07627f3081e02f0ff07551df51529).
+  """
+  test "counterexample 1" do
+    [n1, n2, n3] = Cluster.start(3)
+
+    Cluster.connect(n1, ["101"])
+    Cluster.connect(n2, ids(201..252))
+    assert eventually(fn ->
+      Cluster.session_ids_on_nodes([n1, n2, n3]) ==
+        List.duplicate(["101"] ++ ids(201..252), 3)
+    end)
+
+    Cluster.stop_node(n3)
+    assert eventually(fn ->
+      Cluster.session_ids_on_nodes([n1, n2]) ==
+        List.duplicate(["101"] ++ ids(201..252), 2)
+    end)
+
+    Cluster.disconnect(ids(201..251))
+    assert eventually(fn ->
+      Cluster.session_ids_on_nodes([n1, n2]) == [["101", "252"], ["101", "252"]]
+    end)
+
+    Cluster.stop_node(n1)
+    assert eventually(fn ->
+      Cluster.session_ids_on_nodes([n2]) == [["252"]]
+    end)
+
+    Cluster.start_node(n3)
+    assert eventually(fn ->
+      Cluster.session_ids_on_nodes([n2, n3]) == [["252"], ["252"]]
+    end, 60, 1_000)
+  end
+
+  @doc """
+  Delta that dominated on a set of replicas that the other node had no knowledge of was sometimes chosen.
+  Fixed with [1b6345c](https://github.com/distributed-owls/phoenix_pubsub/commit/1b6345c2025fcd618f21fd41585cee58d3302fe9).
+  """
+  test "counterexample 2" do
+    [n1, n2, n3] = Cluster.start(3)
+
+    Cluster.stop_node(n1)
+    assert eventually(fn ->
+      Cluster.session_ids_on_nodes([n2, n3]) == [[], []]
+    end)
+
+    Cluster.connect(n2, ids(201..270))
+    Cluster.connect(n3, ids(301..383))
+    assert eventually(fn ->
+      Cluster.session_ids_on_nodes([n2, n3]) == 
+        List.duplicate(ids(201..270) ++ ids(301..383), 2)
+    end)
+
+    Cluster.stop_node(n3)
+    assert eventually(fn ->
+      Cluster.session_ids_on_nodes([n2]) == [ids(201..270)]
+    end)
+
+    Cluster.start_node(n1)
+    assert eventually(fn ->
+      Cluster.session_ids_on_nodes([n1, n2]) == List.duplicate(ids(201..270), 2)
+    end, 60, 1_000)
+  end
+
+  defp ids(range), do: Enum.map(range, &Integer.to_string/1)
+end


### PR DESCRIPTION
This PR:
* fixes too short waiting time in `eventually`;
* splits counterexamples into 2 parts, found when starting/stopping nodes and when netsplits are created/healed;
* each counterexample is described briefly with a link to a commit that fixed it;
* is using `phoenixframework/phoenix_pubsub` as all the fixes have been merged.