### PR TITLE
Speedup tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ make docker
 
 Run basic tests and extracted counterexamples:
 ```bash
-make test
+TRACKER=pp make test
 ```
 
 Run property tests. Currently, you can customize number of tests in the test file:
 ```bash
-make props
+TRACKER=pp make props
 ```

--- a/lib/breaking_pp/real_world/cluster.ex
+++ b/lib/breaking_pp/real_world/cluster.ex
@@ -8,7 +8,10 @@ defmodule BreakingPP.RealWorld.Cluster do
     Sessions.new()
     {_, 0} = cmd(["stop_cluster"])
     {_, 0} = cmd(["create_network"])
-    Enum.map(1..size, fn i -> create_node(i, size) end)
+
+    1..size
+    |> Enum.map(&Task.async(fn -> create_node(&1, size) end))
+    |> Enum.map(&Task.await(&1, 60_000))
   end
 
   defp create_node(node_id, cluster_size) do

--- a/test/large/cluster_prop_test.exs
+++ b/test/large/cluster_prop_test.exs
@@ -15,6 +15,7 @@ defmodule BreakingPP.Test.ClusterPropTest do
       forall cmds in commands(__MODULE__) do
         {history, state, result} = run_commands(__MODULE__, cmds)
         (result == :ok)
+        |> collect(session_count_range(state, 100))
         |> when_fail(IO.puts """
           History: #{inspect history, pretty: true, limit: :infinity}
           State: #{inspect state, pretty: true, limit: :infinity}
@@ -265,4 +266,12 @@ defmodule BreakingPP.Test.ClusterPropTest do
 
   defp running_node(state), do: oneof(Model.Cluster.started_nodes(state))
   defp stopped_node(state), do: oneof(Model.Cluster.stopped_nodes(state))
+
+  defp session_count_range(state, range_size) do
+    session_count = Model.Cluster.sessions(state) |> Enum.count
+    lower_bound = div(session_count, range_size) * range_size
+    upper_bound = lower_bound + range_size - 1
+    {lower_bound, upper_bound}
+  end
+
 end


### PR DESCRIPTION
This speeds up tests a little bit by starting the application containers in parallel and verifying the postcondition every fourth command.

It also collects information about the session count during the course of running all the property tests.

These tests have been executed against the current master of `phoenix_pubsub` (with `max_size: 100`): https://github.com/phoenixframework/phoenix_pubsub/commit/50c1da2edd441b7af53dc646c92eaee3725a94a2

And passed:
<img width="442" alt="screen shot 2018-12-09 at 11 31 43 am" src="https://user-images.githubusercontent.com/1367110/49896128-b8713380-fe52-11e8-8c65-df475663c6ec.png">

Running these tests against the commits without the suitable fixes failed after 2-3 hours of running.